### PR TITLE
Restrict Thread interface name to `wpan0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Change using `sudo snap openthread-border-router set key="value"`
 
 > **Note**  
 > The snap defines a dbus interface only for a Thread interface named `wpan0`.
-> Running the snap with another interface name is only possible in [dev mode](https://snapcraft.io/docs/install-modes), or after modifying the interface definition in the snapscraft file.
+> Running the snap with another interface name is only possible in [dev mode](https://snapcraft.io/docs/install-modes), or after modifying the interface definition in the snapcraft file.
 
 ### Grant access to resources
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ thread-if  wpan0
 
 Change using `sudo snap openthread-border-router set key="value"`
 
+> **Note**  
+> The snap defines a dbus interface only for a Thread interface named `wpan0`.
+> Running the snap with another interface name is only possible in [dev mode](https://snapcraft.io/docs/install-modes), or after modifying the interface definition in the snapscraft file.
+
 ### Grant access to resources
 
 Connect interfaces to access desired resources:

--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ thread-if  wpan0
 
 Change using `sudo snap openthread-border-router set key="value"`
 
-> **Note**  
-> The snap defines a dbus interface only for a Thread interface named `wpan0`.
-> Running the snap with another interface name is only possible in [dev mode](https://snapcraft.io/docs/install-modes), or after modifying the interface definition in the snapcraft file.
-
 ### Grant access to resources
 
 Connect interfaces to access desired resources:

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -3,6 +3,6 @@
 # Placeholder to allow setting snap configurations
 
 if [ "$(snapctl get thread-if)" != "wpan0" ]; then
-    echo "Thread interface name cannot be configured as 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"
+    echo "Thread interface name cannot be re-configured since 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"
     exit 1
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,8 @@
 #!/bin/bash
 
 # Placeholder to allow setting snap configurations
+
+if [ "$(snapctl get thread-if)" != "wpan0" ]; then
+    echo "Thread interface name cannot be configured as 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"
+    exit 1
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Placeholder to allow setting snap configurations
 
 if [ "$(snapctl get thread-if)" != "wpan0" ]; then
     echo "Thread interface name cannot be re-configured since 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"


### PR DESCRIPTION
The interface name is hardcoded in the upstream [otbr-firewall](https://github.com/openthread/ot-br-posix/blob/thread-reference-20230119/script/otbr-firewall#L41) code as well as the [DBus interface name in snapcraft.yaml](https://github.com/canonical/openthread-border-router-snap/blob/3aa43fa084e40da936ae30b65cf33c9bc35c9b62/snap/snapcraft.yaml#L22).

This PR modifies the configure hook to restrict changes to the `thread-if` snap option.