### PR TITLE
Correct snap set command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ radio-url  spinel+hdlc+uart:///dev/ttyACM0
 thread-if  wpan0
 ```
 
-Change using `sudo snap openthread-border-router set key="value"`
+Change using `sudo snap set openthread-border-router key="value"`
 
 ### Grant access to resources
 


### PR DESCRIPTION
This PR fixes the command in README.

```
$ sudo snap openthread-border-router set infra-if=eno1
error: unknown command "openthread-border-router", see 'snap help'.
```

