### PR TITLE
Add snap option to control service startup

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+TAG="$SNAP_NAME.configure"
+
+logger --tag=$TAG "Start"
 
 if [ "$(snapctl get thread-if)" != "wpan0" ]; then
     echo "Thread interface name cannot be re-configured since 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"
     exit 1
 fi
+
+logger --tag=$TAG "End"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -5,7 +5,7 @@ TAG="$SNAP_NAME.configure"
 logger --tag=$TAG "Start"
 
 if [ "$(snapctl get thread-if)" != "wpan0" ]; then
-    echo "Thread interface name cannot be re-configured since 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"
+    logger --tag=$TAG --stderr "Thread interface name cannot be re-configured since 'wpan0' has been hardcoded in setup scripts as well as the DBus policy"
     exit 1
 fi
 

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -7,15 +7,14 @@ logger --tag=$TAG "Start"
 autostart="$(snapctl get autostart)"
 
 if [ -z "$autostart" ]; then
-    echo "'autostart' is unset."
+    logger --tag=$TAG "'autostart' is unset."
 elif [ "$autostart" = true ]; then
-    echo "'autostart' is enabled ($autostart). Starting and enabling openthread-border-router snap."
+    logger --tag=$TAG "'autostart' is enabled ($autostart): starting and enabling openthread-border-router services."
     snapctl start --enable openthread-border-router
 elif [ "$autostart" = false ]; then
-    echo "'autostart' is disabled ($autostart)."    
+    logger --tag=$TAG "'autostart' is disabled ($autostart)."    
 else
-    echo $TAG "Invalid value for 'autostart': $autostart"
-    exit 1
+    logger --tag=$TAG --stderr "Invalid value for 'autostart': $autostart"
 fi
 
 logger --tag=$TAG "End"

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -4,13 +4,14 @@ TAG="$SNAP_NAME.default-configure"
 
 logger --tag=$TAG "Start"
 
-logger --tag=$TAG "'autostart':"$(snapctl get autostart)""
+autostart_value="$(snapctl get autostart)"
+logger --tag=$TAG "'autostart': $autostart_value"
 
-if [ "$autostart" = true ]; then
+if [ "$autostart_value" = "true" ]; then
     logger --tag=$TAG "'autostart' is enabled: starting and enabling openthread-border-router services."
-    snapctl start --enable openthread-border-router  
-else
-    logger --tag=$TAG --stderr "Invalid value for 'autostart': $autostart"
+    snapctl start --enable openthread-border-router
+elif [ -n "$autostart_value" ] && [ "$autostart_value" != "false" ]; then
+    logger --tag=$TAG --stderr "Invalid value for 'autostart': $autostart_value"
     exit 1
 fi
 

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -4,17 +4,14 @@ TAG="$SNAP_NAME.default-configure"
 
 logger --tag=$TAG "Start"
 
-autostart="$(snapctl get autostart)"
+logger --tag=$TAG "'autostart':"$(snapctl get autostart)""
 
-if [ -z "$autostart" ]; then
-    logger --tag=$TAG "'autostart' is unset."
-elif [ "$autostart" = true ]; then
-    logger --tag=$TAG "'autostart' is enabled ($autostart): starting and enabling openthread-border-router services."
-    snapctl start --enable openthread-border-router
-elif [ "$autostart" = false ]; then
-    logger --tag=$TAG "'autostart' is disabled ($autostart)."    
+if [ "$autostart" = true ]; then
+    logger --tag=$TAG "'autostart' is enabled: starting and enabling openthread-border-router services."
+    snapctl start --enable openthread-border-router  
 else
     logger --tag=$TAG --stderr "Invalid value for 'autostart': $autostart"
+    exit 1
 fi
 
 logger --tag=$TAG "End"

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+TAG="$SNAP_NAME.default-configure"
+
+logger --tag=$TAG "Start"
+
+autostart="$(snapctl get autostart)"
+
+if [ -z "$autostart" ]; then
+    echo "'autostart' is unset."
+elif [ "$autostart" = true ]; then
+    echo "'autostart' is enabled ($autostart). Starting and enabling openthread-border-router snap."
+    snapctl start --enable openthread-border-router
+elif [ "$autostart" = false ]; then
+    echo "'autostart' is disabled ($autostart)."    
+else
+    echo $TAG "Invalid value for 'autostart': $autostart"
+    exit 1
+fi
+
+logger --tag=$TAG "End"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -8,6 +8,7 @@ logger --tag=$TAG "Start"
 snapctl set infra-if=wlan0
 snapctl set thread-if=wpan0
 snapctl set radio-url="spinel+hdlc+uart:///dev/ttyACM0"
+snapctl set autostart=false
 
 mkdir -p $SNAP_COMMON/thread-data
 


### PR DESCRIPTION
The default-configure hook will be called only once during installation:
```
$ snap logs -f openthread-border-router
ubuntu openthread-border-router.install[221901]: Start
ubuntu openthread-border-router.install[221918]: End
...
ubuntu openthread-border-router.default-configure[302008]: Start
ubuntu openthread-border-router.default-configure[302015]: 'autostart':
ubuntu openthread-border-router.default-configure[302016]: End
...
ubuntu openthread-border-router.configure[221970]: Start
ubuntu openthread-border-router.configure[221976]: End
```