### PR TITLE
Add autostart snap option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ sudo snap connect openthread-border-router:bluez
 > sudo snap connect openthread-border-router:avahi-control avahi:avahi-control
 > sudo snap connect openthread-border-router:bluez bluez:service
 > ```
-> 
+
+### Control service startup
+By default, the services do not run on reboot. The snap provides an `autostart` option to change the default service startup behavior. 
+This is also useful for changing the startup behavior when seeding the snap from a [Gadget](https://snapcraft.io/docs/the-gadget-snap) on [Ubuntu Core](https://ubuntu.com/core).
+
+For instance, to start and enable services by setting `autostart` to true:
+```
+sudo snap set openthread-border-router autostart=true
+```
 
 ## Run
 Start once:


### PR DESCRIPTION
This PR documents changes made by https://github.com/canonical/openthread-border-router-snap/pull/31