### PR TITLE
Add snap options for otbr-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ To build locally and install, refer [here](#build).
 View default configurations:
 ```bash
 $ sudo snap get openthread-border-router 
-Key             Value
-infra-if        wlan0
-radio-url       spinel+hdlc+uart:///dev/ttyACM0
-thread-if       wpan0
+Key                    Value
+infra-if               wlan0
+radio-url              spinel+hdlc+uart:///dev/ttyACM0
+thread-if              wpan0
 
-listen-address  "::"
-port            80
+webgui-listen-address  "::"
+webgui-port            80
 ```
 
 Change using `sudo snap set openthread-border-router key="value"`

--- a/README.md
+++ b/README.md
@@ -27,10 +27,14 @@ To build locally and install, refer [here](#build).
 View default configurations:
 ```bash
 $ sudo snap get openthread-border-router 
-Key        Value
-infra-if   wlan0
-radio-url  spinel+hdlc+uart:///dev/ttyACM0
-thread-if  wpan0
+Key             Value
+infra-if        wlan0
+radio-url       spinel+hdlc+uart:///dev/ttyACM0
+thread-if       wpan0
+
+interface-name  wpan0
+listen-address  "0.0.0.0"
+port            80
 ```
 
 Change using `sudo snap set openthread-border-router key="value"`

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ infra-if        wlan0
 radio-url       spinel+hdlc+uart:///dev/ttyACM0
 thread-if       wpan0
 
-interface-name  wpan0
-listen-address  "0.0.0.0"
+listen-address  "::"
 port            80
 ```
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,6 +10,9 @@ snapctl set infra-if=wlan0
 snapctl set thread-if=wpan0
 snapctl set radio-url="spinel+hdlc+uart:///dev/ttyACM0"
 snapctl set autostart=false
+snapctl set interface-name=wpan0
+snapctl set listen-address="0.0.0.0"
+snapctl set port=80
 set +x
 
 mkdir -p $SNAP_COMMON/thread-data

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,8 +10,7 @@ snapctl set infra-if=wlan0
 snapctl set thread-if=wpan0
 snapctl set radio-url="spinel+hdlc+uart:///dev/ttyACM0"
 snapctl set autostart=false
-snapctl set interface-name=wpan0
-snapctl set listen-address="0.0.0.0"
+snapctl set listen-address="::"
 snapctl set port=80
 set +x
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -10,8 +10,8 @@ snapctl set infra-if=wlan0
 snapctl set thread-if=wpan0
 snapctl set radio-url="spinel+hdlc+uart:///dev/ttyACM0"
 snapctl set autostart=false
-snapctl set listen-address="::"
-snapctl set port=80
+snapctl set webgui-listen-address="::"
+snapctl set webgui-port=80
 set +x
 
 mkdir -p $SNAP_COMMON/thread-data

--- a/snap/local/stage/bin/otbr-web.sh
+++ b/snap/local/stage/bin/otbr-web.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -ex
 
-export INTERFACE_NAME=$(snapctl get interface-name)
 export LISTEN_ADDRESS=$(snapctl get listen-address)
 export PORT=$(snapctl get port)
 
-exec $SNAP/bin/otbr-web -I $INTERFACE_NAME -a $LISTEN_ADDRESS -p $PORT
+exec $SNAP/bin/otbr-web -a "$LISTEN_ADDRESS" -p $PORT
 
 # Usage: otbr-web [-d DEBUG_LEVEL] [-I interfaceName] [-p port] [-a listenAddress] [-v]

--- a/snap/local/stage/bin/otbr-web.sh
+++ b/snap/local/stage/bin/otbr-web.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+export INTERFACE_NAME=$(snapctl get interface-name)
+export LISTEN_ADDRESS=$(snapctl get listen-address)
+export PORT=$(snapctl get port)
+
+exec $SNAP/bin/otbr-web -I $INTERFACE_NAME -a $LISTEN_ADDRESS -p $PORT
+
+# Usage: otbr-web [-d DEBUG_LEVEL] [-I interfaceName] [-p port] [-a listenAddress] [-v]

--- a/snap/local/stage/bin/otbr-web.sh
+++ b/snap/local/stage/bin/otbr-web.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -ex
 
-export LISTEN_ADDRESS=$(snapctl get listen-address)
-export PORT=$(snapctl get port)
+export THREAD_IF=$(snapctl get thread-if)
+export WEBGUI_LISTEN_ADDRESS=$(snapctl get webgui-listen-address)
+export WEBGUI_PORT=$(snapctl get webgui-port)
 
-exec $SNAP/bin/otbr-web -I $THREAD_IF -a "$LISTEN_ADDRESS" -p $PORT
+exec $SNAP/bin/otbr-web -I $THREAD_IF -a $WEBGUI_LISTEN_ADDRESS -p $WEBGUI_PORT
 
 # Usage: otbr-web [-d DEBUG_LEVEL] [-I interfaceName] [-p port] [-a listenAddress] [-v]

--- a/snap/local/stage/bin/otbr-web.sh
+++ b/snap/local/stage/bin/otbr-web.sh
@@ -3,6 +3,6 @@
 export LISTEN_ADDRESS=$(snapctl get listen-address)
 export PORT=$(snapctl get port)
 
-exec $SNAP/bin/otbr-web -a "$LISTEN_ADDRESS" -p $PORT
+exec $SNAP/bin/otbr-web -I $THREAD_IF -a "$LISTEN_ADDRESS" -p $PORT
 
 # Usage: otbr-web [-d DEBUG_LEVEL] [-I interfaceName] [-p port] [-a listenAddress] [-v]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ apps:
   otbr-web:
     after: 
       - otbr-agent
-    command: bin/otbr-web
+    command: bin/otbr-web.sh
     daemon: simple
     install-mode: disable
     # restart-delay: 3s


### PR DESCRIPTION
This PR will resolve #15 

# Testing instruction
Install and setup otbr snap:
```
snap remove --purge openthread-border-router
sudo snap install ./openthread-border-router_thread-reference-20230119+snap_amd64.snap --dangerous

sudo snap connect openthread-border-router:avahi-control
sudo snap connect openthread-border-router:firewall-control
sudo snap connect openthread-border-router:raw-usb
sudo snap connect openthread-border-router:network-control
sudo snap connect openthread-border-router:bluetooth-control
sudo snap connect openthread-border-router:bluez
sudo snap start openthread-border-router
```

Set new otbr-web arguments:
```
sudo snap set openthread-border-router webgui-listen-address=192.168.178.38
sudo snap set openthread-border-router webgui-port=82
sudo snap restart openthread-border-router.otbr-web
```

Check the logs simultaneously:
```
$ journalctl -f | grep openthread
systemd[1]: Stopped Service for snap application openthread-border-router.otbr-web.
systemd[1]: Started Service for snap application openthread-border-router.otbr-web.
openthread-border-router.otbr-web[187123]: ++ snapctl get thread-if
openthread-border-router.otbr-web[187095]: + export THREAD_IF=wpan0
openthread-border-router.otbr-web[187095]: + THREAD_IF=wpan0
openthread-border-router.otbr-web[187129]: ++ snapctl get webgui-listen-address
openthread-border-router.otbr-web[187095]: + export WEBGUI_LISTEN_ADDRESS=192.168.178.38
openthread-border-router.otbr-web[187095]: + WEBGUI_LISTEN_ADDRESS=192.168.178.38
openthread-border-router.otbr-web[187134]: ++ snapctl get webgui-port
openthread-border-router.otbr-web[187095]: + export WEBGUI_PORT=82
openthread-border-router.otbr-web[187095]: + WEBGUI_PORT=82
openthread-border-router.otbr-web[187095]: + exec /snap/openthread-border-router/x1/bin/otbr-web -I wpan0 -a 192.168.178.38 -p 82
openthread-border-router.otbr-web[187095]: otbr-web[187095]: [INFO]-WEB-----: Running 0.3.0-thread-reference-20230119-dirty
openthread-border-router.otbr-web[187095]: otbr-web[187095]: [INFO]-WEB-----: Border router web started on wpan0
```

Validate that only the specific address and port have access to the OTBR web server:
```
$ curl 192.168.178.38:82
<!DOCTYPE html>
<!--
  Copyright 2017 Openthread authors. All rights reserved.
...

ubuntu@ubuntu:~$ curl 127.0.0.1:82
curl: (7) Failed to connect to 127.0.0.1 port 82 after 0 ms: Connection refused
ubuntu@ubuntu:~$ curl 192.168.178.38:80
curl: (7) Failed to connect to 192.168.178.38 port 80 after 3 ms: Connection refused
```

