### PR TITLE
Upgrade OTBR snap to thread-reference-20230710

### DIFF
--- a/snap/local/stage/bin/otbr-setup.sh
+++ b/snap/local/stage/bin/otbr-setup.sh
@@ -49,14 +49,14 @@ source $SNAP/bin/_initrc_install
 ###############################################################################
 echo "Setup IP forwarding"
 # Upstream equivalent:
-# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230119/script/_ipforward
+# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230710/script/_ipforward
 sysctl -w net.ipv6.conf.all.forwarding=1
 sysctl -w net.ipv4.ip_forward=1
 
 ###############################################################################
 echo "Setup RT Tables for the Backbone Router"
 # Upstream equivalent:
-# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230119/script/_rt_tables
+# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230710/script/_rt_tables
 # Skip setting "88 openthread" routing table mapping:
 # https://github.com/canonical/openthread-border-router-snap/issues/14
 sysctl net.core.optmem_max=65536
@@ -66,7 +66,7 @@ echo "Setup NAT44"
 # The nat44_install function in scripts/_nat64 creates a service file and sets 
 # firewall rules inside. We are only interested in the firewall rules.
 # Upstream source: 
-# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230119/script/_nat64
+# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230710/script/_nat64
 echo "Set random fwmark bits"
 iptables -t mangle -A PREROUTING -i $THREAD_IF -j MARK --set-mark 0x1001 -m comment --comment "OTBR"
 iptables -t nat -A POSTROUTING -m mark --mark 0x1001 -j MASQUERADE -m comment --comment "OTBR"
@@ -78,7 +78,7 @@ iptables -t filter -A FORWARD -i $INFRA_IF -j ACCEPT -m comment --comment "OTBR"
 ###############################################################################
 echo "Setup Border Routing"
 # Upstream equivalent:
-# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230119/script/_border_routing
+# https://github.com/openthread/ot-br-posix/blob/thread-reference-20230710/script/_border_routing
 sysctl -w net.ipv6.conf.$INFRA_IF.accept_ra=2
 sysctl -w net.ipv6.conf.$INFRA_IF.accept_ra_rt_info_max_plen=64
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -106,7 +106,7 @@ parts:
     after:
       - build-bin
     source: https://github.com/openthread/ot-br-posix.git
-    source-tag: thread-reference-20230119
+    source-tag: thread-reference-20230710
     source-depth: 1
     plugin: nil
     build-packages: 
@@ -144,6 +144,7 @@ parts:
       - dhcpcd5
       - libatm1
       - libjsoncpp-dev
+      - libprotobuf-lite23
     override-build: |
       craftctl set version="$(git describe --tags)+snap"
 


### PR DESCRIPTION
This PR upgrades OTBR snap to use the latest/stable([thread-reference-20230710](https://github.com/openthread/ot-br-posix/releases/tag/thread-reference-20230710)) release. 

This snap could be installed by the following command:
```
snap install openthread-border-router --channel=edge/pr-41
```
Checklists for upgrade:
/openthread-border-router-snap/snap/local$ tree .
.
├── build
│   └── bin
│       ├── _initrc (no update)
│       └── otbr-build.sh (already updated)
└── stage
    └── bin
        ├── _initrc_install (no update)
        ├── otbr-agent.sh (not applicable)
        ├── otbr-setup.sh (no update)
        └── otbr-web.sh (not applicable)
        
- [x] script/_ipforward (no update)
- [x] script/_rt_tables (no update)
- [x] script/_nat64 (already updated)
- [x] script/_border_routing (already updated)
- [x] script/_disable_services (not applicable)
- [x] script/_otbr (not applicable)
- [x] script/bootstrap (not applicable)
- [x] script/clang-format (not applicable)
- [x] script/cmake-build (not applicable)
- [x] script/console (not applicable)
- [x] script/make-pretty (not applicable)
- [x] script/server (not applicable)
- [x] script/standalone_ipv6 (not applicable)
- [x] _initrc (no update)
- [x] _initrc_install (no update)
- [x] otbr-build.sh (already updated)

# Testing
- [x] Thread network formation
- [x] check reboot
- [x] automated OTBR snap testing:
```
$ LOCAL_SERVICE_SNAP=../../../806/openthread-border-router-snap/openthread-border-router_thread-reference-20230710+snap_amd64.snap INFRA_IF="eno1" go test -v -failfast -count 1 .
2024/02/16 16:44:51 [CLEAN]
2024/02/16 16:44:51 [exec] sudo snap remove --purge openthread-border-router
2024/02/16 16:44:51 [stderr] snap "openthread-border-router" is not installed
2024/02/16 16:44:51 [SETUP]
2024/02/16 16:44:51 [exec] sudo snap install --dangerous ../../../806/openthread-border-router-snap/openthread-border-router_thread-reference-20230710+snap_amd64.snap
2024/02/16 16:44:53 [stdout] openthread-border-router thread-reference-20230710+snap installed
2024/02/16 16:44:53 [exec] sudo snap connect openthread-border-router:avahi-control 
2024/02/16 16:44:54 [exec] sudo snap connect openthread-border-router:firewall-control 
2024/02/16 16:44:54 [exec] sudo snap connect openthread-border-router:raw-usb 
2024/02/16 16:44:55 [exec] sudo snap connect openthread-border-router:network-control 
2024/02/16 16:44:55 [exec] sudo snap connect openthread-border-router:bluetooth-control 
2024/02/16 16:44:56 [exec] sudo snap connect openthread-border-router:bluez 
2024/02/16 16:44:56 [exec] sudo cp ot-rcp-simulator-thread-reference-20230119-amd64 /var/snap/openthread-border-router/common/
2024/02/16 16:44:56 [exec] sudo snap set openthread-border-router radio-url=''spinel+hdlc+forkpty:///var/snap/openthread-border-router/common/ot-rcp-simulator-thread-reference-20230119-amd64?forkpty-arg=1''
2024/02/16 16:44:57 [exec] sudo snap set openthread-border-router infra-if='eno1'
=== RUN   TestConfig
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== RUN   TestConfig/Set_infra-if
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
    exec.go:32: [exec] sudo snap set openthread-border-router infra-if='wpan1'
    config_test.go:27: [exec] sudo snap start openthread-border-router
    config.go:59: Retry 1/10: Waiting for expected content in logs: INFRA_IF=wpan1
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:44:57" --no-pager | grep "openthread-border-router.otbr-setup"|| true
    config.go:63: Found expected content in logs: INFRA_IF=wpan1
    exec.go:32: [exec] sudo snap set openthread-border-router infra-if='eno1'
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== RUN   TestConfig/Set_radio-url
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
    exec.go:32: [exec] sudo snap set openthread-border-router radio-url='spinel+hdlc+uart:///dev/ttyACM1'
    config_test.go:34: [exec] sudo snap start openthread-border-router
    config.go:59: Retry 1/10: Waiting for expected content in logs: RADIO_URL=spinel+hdlc+uart:///dev/ttyACM1
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:00" --no-pager | grep "openthread-border-router.otbr-agent"|| true
    config.go:63: Found expected content in logs: RADIO_URL=spinel+hdlc+uart:///dev/ttyACM1
    exec.go:32: [exec] sudo snap set openthread-border-router radio-url=''spinel+hdlc+forkpty:///var/snap/openthread-border-router/common/ot-rcp-simulator-thread-reference-20230119-amd64?forkpty-arg=1''
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== RUN   TestConfig/Set_invalid_thread_interface
    config_test.go:49: [exec] sudo snap set openthread-border-router thread-if=wpan1
    exec.go:32: [exec] sudo snap set openthread-border-router thread-if='wpan0'
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== RUN   TestConfig/Set_webgui-listen-address
    exec.go:32: [exec] sudo lsof -nPi :80 || true
    net.go:202: Port 80 is available.
    exec.go:32: [exec] sudo snap set openthread-border-router webgui-listen-address='127.0.0.1'
    exec.go:32: [exec] sudo snap start --enable openthread-border-router
    exec.go:118: [stdout] Started.
    net.go:96: Retry 1/10: Waiting for ports: 80
    exec.go:32: [exec] sudo snap set openthread-border-router webgui-listen-address='::'
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== RUN   TestConfig/Set_webgui-port
    exec.go:32: [exec] sudo lsof -nPi :90 || true
    net.go:202: Port 90 is available.
    exec.go:32: [exec] sudo snap set openthread-border-router webgui-port='90'
2024/02/16 16:45:05 [exec] sudo snap start --enable openthread-border-router
2024/02/16 16:45:06 [stdout] Started.
    net.go:96: Retry 1/10: Waiting for ports: 90
    net.go:96: Retry 2/10: Waiting for ports: 90
    net.go:96: Retry 1/10: Waiting for ports: 90
    exec.go:32: [exec] sudo snap set openthread-border-router webgui-port='80'
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== RUN   TestConfig/Set_autostart
    exec.go:32: [exec] snap services openthread-border-router | awk 'FNR == 2 {print $2}'
    exec.go:118: [stdout] disabled
    exec.go:32: [exec] snap services openthread-border-router | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] inactive
    exec.go:32: [exec] sudo snap set openthread-border-router autostart='true'
    exec.go:32: [exec] snap services openthread-border-router.otbr-agent | awk 'FNR == 2 {print $2}'
    exec.go:118: [stdout] enabled
    exec.go:32: [exec] snap services openthread-border-router.otbr-agent | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] active
    exec.go:32: [exec] snap services openthread-border-router.otbr-web | awk 'FNR == 2 {print $2}'
    exec.go:118: [stdout] enabled
    exec.go:32: [exec] snap services openthread-border-router.otbr-web | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] active
    exec.go:32: [exec] snap services openthread-border-router.otbr-setup | awk 'FNR == 2 {print $2}'
    exec.go:118: [stdout] enabled
    exec.go:32: [exec] snap services openthread-border-router.otbr-setup | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] inactive
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
=== NAME  TestConfig
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
--- PASS: TestConfig (12.65s)
    --- PASS: TestConfig/Set_infra-if (2.70s)
    --- PASS: TestConfig/Set_radio-url (2.67s)
    --- PASS: TestConfig/Set_invalid_thread_interface (0.67s)
    --- PASS: TestConfig/Set_webgui-listen-address (1.70s)
    --- PASS: TestConfig/Set_webgui-port (2.59s)
    --- PASS: TestConfig/Set_autostart (1.63s)
=== RUN   TestSetup
    exec.go:32: [exec] sudo snap get openthread-border-router infra-if
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
2024/02/16 16:45:10 [exec] sudo snap start --enable openthread-border-router
2024/02/16 16:45:11 [stdout] Started.
=== RUN   TestSetup/Firewall_rule
    exec.go:32: [exec] sudo iptables -S FORWARD | grep "comment OTBR"
=== RUN   TestSetup/IP_forwarding
    exec.go:32: [exec] sudo sysctl net.ipv6.conf.all.forwarding
    exec.go:32: [exec] sudo sysctl net.ipv4.ip_forward
=== RUN   TestSetup/RT_tables_for_backbone_router
    exec.go:32: [exec] sudo sysctl net.core.optmem_max
=== RUN   TestSetup/Random_fwmark_bits
    exec.go:32: [exec] sudo iptables -t mangle -L PREROUTING -n -v | grep OTBR
    exec.go:32: [exec] sudo iptables -t nat -L POSTROUTING -n -v | grep OTBR
=== RUN   TestSetup/Firewall_rule_setup_for_Infrastructure_interface
    exec.go:32: [exec] sudo iptables -t filter -L FORWARD -n -v | grep OTBR | grep eno1
=== RUN   TestSetup/Border_routing
    exec.go:32: [exec] sudo sysctl net.ipv6.conf.eno1.accept_ra
    exec.go:32: [exec] sudo sysctl net.ipv6.conf.eno1.accept_ra_rt_info_max_plen
=== NAME  TestSetup
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
--- PASS: TestSetup (1.67s)
    --- PASS: TestSetup/Firewall_rule (0.01s)
    --- PASS: TestSetup/IP_forwarding (0.02s)
    --- PASS: TestSetup/RT_tables_for_backbone_router (0.01s)
    --- PASS: TestSetup/Random_fwmark_bits (0.02s)
    --- PASS: TestSetup/Firewall_rule_setup_for_Infrastructure_interface (0.01s)
    --- PASS: TestSetup/Border_routing (0.01s)
=== RUN   TestSnapServicesStatus
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
2024/02/16 16:45:12 [exec] sudo snap start --enable openthread-border-router
2024/02/16 16:45:12 [stdout] Started.
    exec.go:32: [exec] snap services openthread-border-router.otbr-setup | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] inactive
    exec.go:32: [exec] snap services openthread-border-router.otbr-web | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] active
    exec.go:32: [exec] snap services openthread-border-router.otbr-agent | awk 'FNR == 2 {print $3}'
    exec.go:118: [stdout] active
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
--- PASS: TestSnapServicesStatus (1.61s)
=== RUN   TestSocketFile
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
2024/02/16 16:45:13 [exec] sudo snap start --enable openthread-border-router
2024/02/16 16:45:14 [stdout] Started.
    socket_test.go:20: Retry 1/10: Waiting for file creation: /run/snap.openthread-border-router/openthread-wpan0.sock
    socket_test.go:20: Socket File exists in: /run/snap.openthread-border-router/openthread-wpan0.sock
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
--- PASS: TestSocketFile (2.57s)
=== RUN   TestThreadNetworkFormation
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
2024/02/16 16:45:16 [exec] sudo snap start --enable openthread-border-router
2024/02/16 16:45:16 [stdout] Started.
    exec.go:32: [exec] sudo openthread-border-router.ot-ctl dataset init new
    exec.go:32: [exec] sudo openthread-border-router.ot-ctl dataset commit active
    exec.go:32: [exec] sudo openthread-border-router.ot-ctl ifconfig up
    exec.go:32: [exec] sudo openthread-border-router.ot-ctl thread start
    config.go:59: Retry 1/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 2/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 3/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 4/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 5/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 6/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 7/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 8/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:59: Retry 9/10: Waiting for expected content in logs: Thread Network
    exec.go:32: [exec] sudo journalctl --since "2024-02-16 16:45:16" --no-pager | grep "openthread-border-router"|| true
    config.go:63: Found expected content in logs: Thread Network
    exec.go:32: [exec] sudo openthread-border-router.ot-ctl state | head -n 1
    exec.go:32: [exec] sudo openthread-border-router.ot-ctl thread stop
    exec.go:32: [exec] sudo snap stop --disable openthread-border-router
    exec.go:118: [stdout] Stopped.
--- PASS: TestThreadNetworkFormation (11.00s)
PASS
2024/02/16 16:45:26 [TEARDOWN]
2024/02/16 16:45:26 [exec] (sudo journalctl --since "2024-02-16 16:44:51" --no-pager | grep "openthread-border-router"|| true) > openthread-border-router.log
Wrote snap logs to /home/mengyi/Desktop/883/openthread-border-router-snap/tests/openthread-border-router.log
2024/02/16 16:45:26 Removing installed snap: true
2024/02/16 16:45:26 [exec] sudo snap remove --purge openthread-border-router
2024/02/16 16:45:31 [stdout] openthread-border-router removed
ok      openthread-border-router-snap-tests     40.271s
```