### PR TITLE
Check application logs in config test

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -117,6 +117,7 @@ func testSettingSnapOption(t *testing.T, configKey, configValue, defaultConfigVa
 	})
 
 	utils.SnapSet(t, otbrSnap, configKey, configValue)
+
 	command := "sudo snap start openthread-border-router"
 	// The error below is not handled as intended
 	// because the configuration value passed here is invalid for the intended purpose
@@ -125,14 +126,15 @@ func testSettingSnapOption(t *testing.T, configKey, configValue, defaultConfigVa
 
 	snapLogLines := 200
 	maxRetry := 10
-	waitForApplicationLogMessage(t, otbrService, expectedLog, snapLogLines, maxRetry)
+	retryInterval := 1 * time.Second
+	waitForApplicationLogMessage(t, otbrService, expectedLog, snapLogLines, maxRetry, retryInterval)
 }
 
-func waitForApplicationLogMessage(t *testing.T, application, expectedLog string, snapLogLines, maxRetry int) {
+func waitForApplicationLogMessage(t *testing.T, application, expectedLog string, snapLogLines, maxRetry int, retryInterval time.Duration) {
 	t.Helper()
 
 	for i := 1; i <= maxRetry; i++ {
-		time.Sleep(1 * time.Second)
+		time.Sleep(retryInterval)
 		t.Logf("Retry %d/%d: Waiting for expected content in application logs: %s", i, maxRetry, expectedLog)
 
 		logs, _, _ := utils.Exec(t, fmt.Sprintf("sudo snap logs -n=%d \"%s\"", snapLogLines, application))


### PR DESCRIPTION
This PR will resolve #43. It checks application logs by calling [`waitForApplicationLogMessage()`](https://github.com/canonical/openthread-border-router-snap/blob/af438da25f859b3a8905916628e16d123e2034d6/tests/config_test.go#L133-L148), which runs [`snap logs`](https://github.com/canonical/openthread-border-router-snap/actions/runs/8388167890/job/22971938188?pr=45#step:5:39) in config test, instead of calling [`utils.WaitForLogMessage()`](https://github.com/canonical/openthread-border-router-snap/blob/main/tests/config_test.go#L124) which runs [`journalctl`](https://github.com/canonical/matter-snap-testing/blob/main/utils/snap.go#L122). 

The `waitForApplicationLogMessage()` function added by this PR could be moved to the [utils](https://github.com/canonical/matter-snap-testing/tree/main/utils) package for wider usage if needed, in case other test suites also need to check application logs.