### PR TITLE
Check services startup completion

### DIFF
--- a/tests/snap_services_test.go
+++ b/tests/snap_services_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/canonical/matter-snap-testing/utils"
 	"github.com/stretchr/testify/require"
@@ -15,12 +16,17 @@ func TestSnapServicesStatus(t *testing.T) {
 		utils.SnapStop(t, otbrSnap)
 	})
 
+	start := time.Now()
 	utils.SnapStart(nil, otbrSnap)
 
 	// Oneshot service
+	utils.WaitForLogMessage(t, otbrSetupApp, "OTBR completed oneshot setup", start)
 	require.False(t, utils.SnapServicesActive(t, otbrSetupApp))
 
 	// Active services
+	utils.WaitForLogMessage(t, otbrWebApp, "Border router web started", start)
 	require.True(t, utils.SnapServicesActive(t, otbrWebApp))
+
+	utils.WaitForLogMessage(t, otbrAgentApp, "Start Thread Border Agent: OK", start)
 	require.True(t, utils.SnapServicesActive(t, otbrAgentApp))
 }


### PR DESCRIPTION
This PR will resolve #42. This PR adds a startup completion check in test suite for each service as below before verifying their active status:
- [otbr-setup](https://github.com/canonical/openthread-border-router-snap/actions/runs/8378912008/job/22944806471?pr=46#step:5:147)
- [otbr-web](https://github.com/canonical/openthread-border-router-snap/actions/runs/8378912008/job/22944806471?pr=46#step:5:152)
- [otbr-agent](https://github.com/canonical/openthread-border-router-snap/actions/runs/8378912008/job/22944806471?pr=46#step:5:157)