### PR TITLE
Fix remove hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -15,6 +15,5 @@ snapctl set webgui-port=80
 set +x
 
 THREAD_DATA=$SNAP_COMMON/thread-data
-
-logger --tag=$TAG "Create directory for thread data: $THREAD_DATA"
+logger --tag=$TAG "Creating directory for thread data: $THREAD_DATA"
 mkdir -p $THREAD_DATA

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -14,4 +14,7 @@ snapctl set webgui-listen-address="::"
 snapctl set webgui-port=80
 set +x
 
-mkdir -p $SNAP_COMMON/thread-data
+THREAD_DATA=$SNAP_COMMON/thread-data
+
+logger --tag=$TAG "Create directory for thread data: $THREAD_DATA"
+mkdir -p $THREAD_DATA

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,16 +1,9 @@
 #!/bin/bash -e
 
-TAG="$SNAP_NAME.remove"
-
-logger --tag=$TAG "Start"
-
+TAG="$SNAP_NAME.hook.remove"
 
 ###############################################################################
 logger --tag=$TAG "Remove the firewall config"
 $SNAP/bin/script/otbr-firewall stop
 
 
-
-rm -f /run/snap.$SNAP_NAME
-
-logger --tag=$TAG "End"

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -6,4 +6,7 @@ TAG="$SNAP_NAME.hook.remove"
 logger --tag=$TAG "Remove the firewall config"
 $SNAP/bin/script/otbr-firewall stop
 
+logger --tag=$TAG "Remove the socket directory"
+# This is created during the OTBR setup
+rm -r /run/snap.$SNAP_NAME
 

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -3,10 +3,10 @@
 TAG="$SNAP_NAME.hook.remove"
 
 ###############################################################################
-logger --tag=$TAG "Remove the firewall config"
+logger --tag=$TAG "Removing the firewall config"
 $SNAP/bin/script/otbr-firewall stop
 
-logger --tag=$TAG "Remove the socket directory"
-# This is created during the OTBR setup
-rm -r /run/snap.$SNAP_NAME
+logger --tag=$TAG "Removing the socket directory"
+# This gets created whenever OTBR setup runs
+rm -fr /run/snap.$SNAP_NAME
 

--- a/snap/local/stage/bin/otbr-setup.sh
+++ b/snap/local/stage/bin/otbr-setup.sh
@@ -30,6 +30,8 @@
 
 echo "OTBR oneshot setup service"
 
+# Create directory for the OpenThread Posix Config Domain Socket
+# This set as a build flag when building OTBR
 mkdir -p /run/snap.$SNAP_NAME
 
 # The operations performed here get reversed upon reboot and removal of the snap.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,9 +29,10 @@ layout:
   /var/lib/thread:
     symlink: $SNAP_COMMON/thread-data
 
-# hooks:
-#     install:
-#         plugs: [network]
+hooks:
+    remove:
+        plugs:
+          - firewall-control
 
 apps:
   otbr-setup:


### PR DESCRIPTION
## Summary
Two fixes for the remove hook:
- Remove the run directory recursively
- Add firewall-control interface connection to allow reverting firewall config from the remove hook

Close #47 

## Testing Steps
Install the snap and start the services. Check the following:
```
$ sudo ip6tables -L OTBR_FORWARD_INGRESS
Chain OTBR_FORWARD_INGRESS (1 references)
target     prot opt source               destination         
DROP       all  --  anywhere             anywhere             PKTTYPE = unicast
DROP       all  --  anywhere             anywhere             match-set otbr-ingress-deny-src src
ACCEPT     all  --  anywhere             anywhere             match-set otbr-ingress-allow-dst dst
DROP       all  --  anywhere             anywhere             PKTTYPE = unicast
ACCEPT     all  --  anywhere             anywhere 
```

Remove the snap, monitor remove hook logs:
```
Jun 24 12:46:20 systemd[1]: Started snap.openthread-border-router.hook.remove-1b1babc7-ac9a-44d4-bbb6-9f95d657df59.scope.
Jun 24 12:46:20 openthread-border-router.hook.remove[52530]: Removing the firewall config
Jun 24 12:46:20 kernel: audit: type=1400 audit(1719225980.405:1398): apparmor="DENIED" operation="exec" class="file" profile="snap.openthread-border-router.hook.remove" name="/usr/bin/systemctl" pid=52535 comm="otbr-firewall" requested_mask="x" denied_mask="x" fsuid=0 ouid=0
Jun 24 12:46:20 kernel: audit: type=1400 audit(1719225980.405:1399): apparmor="DENIED" operation="open" class="file" profile="snap.openthread-border-router.hook.remove" name="/usr/bin/systemctl" pid=52535 comm="otbr-firewall" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
Jun 24 12:46:20 kernel: audit: type=1400 audit(1719225980.409:1400): apparmor="DENIED" operation="exec" class="file" profile="snap.openthread-border-router.hook.remove" name="/usr/bin/plymouth" pid=52537 comm="otbr-firewall" requested_mask="x" denied_mask="x" fsuid=0 ouid=0
Jun 24 12:46:20 kernel: audit: type=1400 audit(1719225980.409:1401): apparmor="DENIED" operation="open" class="file" profile="snap.openthread-border-router.hook.remove" name="/usr/bin/plymouth" pid=52537 comm="otbr-firewall" requested_mask="r" denied_mask="r" fsuid=0 ouid=0
Jun 24 12:46:20 openthread-border-router.hook.remove[52545]: Removing the socket directory
Jun 24 12:46:20 systemd[1]: snap.openthread-border-router.hook.remove-1b1babc7-ac9a-44d4-bbb6-9f95d657df59.scope: Deactivated successfully.
```

Verify the following:
```
$ sudo ip6tables -L OTBR_FORWARD_INGRESS
ip6tables v1.8.9 (nf_tables): chain `OTBR_FORWARD_INGRESS' in table `filter' is incompatible, use 'nft' tool.

$ ls /run/snap.openthread-border-router
ls: cannot access '/run/snap.openthread-border-router': No such file or directory
```

When following the above steps using a revision prior to this PR:
```
$ sudo iptables -S FORWARD | grep "comment OTBR"
-A FORWARD -o enp2s0 -m comment --comment OTBR -j ACCEPT
-A FORWARD -i enp2s0 -m comment --comment OTBR -j ACCEPT
-A FORWARD -o enp2s0 -m comment --comment OTBR -j ACCEPT
-A FORWARD -i enp2s0 -m comment --comment OTBR -j ACCEPT
-A FORWARD -o enp2s0 -m comment --comment OTBR -j ACCEPT
-A FORWARD -i enp2s0 -m comment --comment OTBR -j ACCEPT

$ ls /run/snap.openthread-border-router
openthread-wpan0.lock
```

Note: the firewall cleanup logic is in [otbr-firewall](https://github.com/openthread/ot-br-posix/blob/41474ce29ab45dd24c393d899c9f461844dc1e34/script/otbr-firewall#L74-L89).

