### PR TITLE
Bump otbr to thread-reference-20250612

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -107,7 +107,7 @@ parts:
     after:
       - build-bin
     source: https://github.com/openthread/ot-br-posix.git
-    source-tag: thread-reference-20230710
+    source-tag: thread-reference-20250612
     source-depth: 1
     plugin: nil
     build-packages: 

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,1 @@
+ot-rcp-simulator-thread-reference-20250612-amd64 filter=lfs diff=lfs merge=lfs -text

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,21 +22,25 @@ INFRA_IF="eth0" go test -v -failfast -count 1
 # Build a Radio Co-Processor (RCP) simulator for testing
 
 In this test, a pre-built RCP simulator will be utilized. 
-The RCP simulator can be built by running the following commands:
+The simulator needs to be built on Ubuntu 22.04 to be compatible with the glibc that will be available to this snap that uses the core22 base.
+A multipass VM can be used for this.
+
 ```bash
-git clone https://github.com/openthread/openthread.git --branch=thread-reference-20230119
+git clone https://github.com/openthread/openthread.git --branch=thread-reference-20250612
 cd openthread
 ./script/bootstrap
 ./script/cmake-build simulation
 ```
 
-Once built, it needs to be relocated to a directory visible to OTBR snap 
-and subsequently passed to OTBR snap using snap options during testing:
+Once built, copy the simulator binary from the Multipass VM into this directory, and rename it to `ot-rcp-simulator-thread-reference-20250612-amd64`.
 ```bash
-sudo cp openthread/build/simulation/examples/apps/ncp/ot-rcp/ot-rcp-simulator-thread-reference-20230119-amd64 \
-    /var/snap/openthread-border-router/common/
+cp build/simulation/examples/apps/ncp/ot-rcp ~/<host-home-dir>/openthread-border-router-snap/tests/ot-rcp-simulator-thread-reference-20250612-amd64
+```
+
+During testing the tests will copy the simulator into the `$SNAP_COMMON` directory,
+and the `radio-url` will be set to its path.
+```bash
 snap set openthread-border-router radio-url='spinel+hdlc+forkpty:///var/snap/openthread-border-router/common/ot-rcp-simulator-thread-reference-20230119-amd64?forkpty-arg=1''
 ```
 
 For additional information regarding RCP simulation, please refer to the [openthread simulation posix](https://openthread.io/codelabs/openthread-simulation-posix#3).
-

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -22,7 +22,7 @@ const (
 	defaultWebGUIPort = "8080"
 	webGuiPortKey     = "webgui-port"
 
-	defaultRadioURL = "'spinel+hdlc+forkpty:///var/snap/openthread-border-router/common/ot-rcp-simulator-thread-reference-20230119-amd64?forkpty-arg=1'"
+	defaultRadioURL = "'spinel+hdlc+forkpty:///var/snap/openthread-border-router/common/ot-rcp-simulator-thread-reference-20250612-amd64?forkpty-arg=1'"
 )
 
 var infraInterfaceValue = defaultInfraInterfaceValue
@@ -75,7 +75,7 @@ func setup() (teardown func(), err error) {
 	utils.SnapConnect(nil, otbrSnap+":bluez", "")
 
 	// Copy and set simulated RCP
-	utils.Exec(nil, "sudo cp ot-rcp-simulator-thread-reference-20230119-amd64 /var/snap/openthread-border-router/common/")
+	utils.Exec(nil, "sudo cp ot-rcp-simulator-thread-reference-20250612-amd64 /var/snap/openthread-border-router/common/")
 	utils.SnapSet(nil, otbrSnap, "radio-url", defaultRadioURL)
 
 	// Get and set infrastructure interface

--- a/tests/ot-rcp-simulator-thread-reference-20250612-amd64
+++ b/tests/ot-rcp-simulator-thread-reference-20250612-amd64
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2a0868ed617d132e8216e891f2020b7c7ed73268ee0425bb2c415c30b1bb27
+size 2372248

--- a/tests/snap_services_test.go
+++ b/tests/snap_services_test.go
@@ -27,6 +27,6 @@ func TestSnapServicesStatus(t *testing.T) {
 	utils.WaitForLogMessage(t, otbrWebApp, "Border router web started", start)
 	require.True(t, utils.SnapServicesActive(t, otbrWebApp))
 
-	utils.WaitForLogMessage(t, otbrAgentApp, "Start Thread Border Agent: OK", start)
+	utils.WaitForLogMessage(t, otbrAgentApp, "[INFO]-BA------: Start Thread Border Agent", start)
 	require.True(t, utils.SnapServicesActive(t, otbrAgentApp))
 }


### PR DESCRIPTION
## Summary
<!-- PR description, link to related documents and PRs -->

* Update OTBR to Thread Reference 20250612
* Update simulator used in smoketesting to the same version
* Change expected log message when OTBR is started up

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->

## Testing steps
<!-- Steps to test the changes -->

- [x] Smoke testing passes: https://github.com/canonical/openthread-border-router-snap/actions/runs/21910165299
- [x] Real world test described below passes

## Real world test description

* Follow tutorial https://canonical-matter.readthedocs-hosted.com/en/latest/how-to/matter-and-thread-on-ubuntu/
* Add Machine B to Thread network (https://github.com/canonical/matter-docs/issues/43)
* Use chiptool to toggle the LED
* Disable WiFi and Ethernet on Machine A and/or Machine B
* Try to toggle LED again
* If this works, the control is definitely via Thread
