### PR TITLE
Core24, process communication socket name fix

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -112,8 +112,8 @@ parts:
     after:
       - build-bin
     source: https://github.com/openthread/ot-br-posix.git
-    source-branch: main
-    # source-tag: thread-reference-20250612
+    source-tag: thread-reference-20250612
+    # source-branch: main
     source-depth: 1
     plugin: nil
     build-packages: 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,11 +4,16 @@ summary: Snap packaging of OpenThread Border Router project for POSIX systems
 description: Refer to https://snapcraft.io/openthread-border-router
 adopt-info: otbr
 
-base: core22
+base: core24
 
-architectures:
-  - build-on: amd64
-  - build-on: arm64
+platforms:
+  amd64:
+    build-on: amd64
+    build-for: amd64
+  arm64:
+    build-on: arm64
+    build-for: arm64
+
 
 grade: devel
 confinement: strict
@@ -107,7 +112,8 @@ parts:
     after:
       - build-bin
     source: https://github.com/openthread/ot-br-posix.git
-    source-tag: thread-reference-20250612
+    source-branch: main
+    # source-tag: thread-reference-20250612
     source-depth: 1
     plugin: nil
     build-packages: 
@@ -145,7 +151,7 @@ parts:
       - dhcpcd5
       - libatm1
       - libjsoncpp-dev
-      - libprotobuf-lite23
+      - libprotobuf-lite32t64
     override-build: |
       craftctl set version="$(git describe --tags)+snap"
 
@@ -163,7 +169,13 @@ parts:
       OTBR_OPTIONS+=" -DOT_CFLAGS=-DOPENTHREAD_POSIX_CONFIG_DAEMON_SOCKET_BASENAME=\"$SNAP_RUN_OTBR\""
       OTBR_OPTIONS+=" -DWEB_CFLAGS=-DOPENTHREAD_POSIX_DAEMON_SOCKET_NAME=\"$SNAP_RUN_OTBR.sock\""
       # OTBR_OPTIONS+=" -DCMAKE_BUILD_TYPE=Debug"
-      
+
+      # Fix missing entry in cmake file.
+      sed -i '/^target_include_directories/i \
+      target_compile_options(otbr-web PRIVATE\
+      )\
+      ' src/web/CMakeLists.txt
+
       # Add the compile option to override the posix socket
       sed -i '/^target_compile_options/a ${WEB_CFLAGS}' src/web/CMakeLists.txt
 


### PR DESCRIPTION
## Summary
Changed core from 22 to 24, updated dependencies accordingly.

Fix: The OTBR tagged thread-reference-20250612 had removed a configuration section in cmake, so the posix socket was not named correctly for the web, hence it could not talk with the agent. Added a sed command to the snapcraft script to patch the cmakelist by adding the missing section.

I'm sorry if this is not how you do stuff on github, this is the first time I've tried to use it, so use this information for what ever, just wanted to share my findings.

## Related issues
## Testing steps
