### PR TITLE
Improve sed replacement patch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -170,12 +170,6 @@ parts:
       OTBR_OPTIONS+=" -DWEB_CFLAGS=-DOPENTHREAD_POSIX_DAEMON_SOCKET_NAME=\"$SNAP_RUN_OTBR.sock\""
       # OTBR_OPTIONS+=" -DCMAKE_BUILD_TYPE=Debug"
 
-      # Fix missing entry in cmake file.
-      sed -i '/^target_include_directories/i \
-      target_compile_options(otbr-web PRIVATE\
-      )\
-      ' src/web/CMakeLists.txt
-
       # Add the compile option to override the posix socket
       sed -i '/^target_include_directories/i \
       target_compile_options(otbr-web PRIVATE\

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,7 +113,6 @@ parts:
       - build-bin
     source: https://github.com/openthread/ot-br-posix.git
     source-tag: thread-reference-20250612
-    # source-branch: main
     source-depth: 1
     plugin: nil
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,8 +57,8 @@ apps:
     daemon: simple
     install-mode: disable
     # restart-delay: 10s
-    plugs: 
-      - network 
+    plugs:
+      - network
       - network-bind
       - network-control
       - avahi-control
@@ -72,7 +72,7 @@ apps:
   # Web GUI
   # The default port is 80
   otbr-web:
-    after: 
+    after:
       - otbr-agent
     command: bin/otbr-web.sh
     daemon: simple
@@ -81,11 +81,11 @@ apps:
     plugs:
       - network
       - network-bind
-    
+
 
   ot-ctl:
     command: bin/ot-ctl
-  
+
   pskc:
     command: bin/pskc
 
@@ -100,7 +100,7 @@ parts:
       # Resources needed for the build
       mkdir -p $SNAPCRAFT_STAGE/snap/bin
       cp -v * $SNAPCRAFT_STAGE/snap/bin
-  
+
   stage-bin:
     plugin: nil
     source: snap/local/stage/bin
@@ -116,14 +116,14 @@ parts:
     # source-branch: main
     source-depth: 1
     plugin: nil
-    build-packages: 
+    build-packages:
       - libreadline-dev
       - libncurses-dev
       - build-essential
       - ninja-build
       - libcpputest-dev
       - libdbus-1-dev
-      - libavahi-common-dev 
+      - libavahi-common-dev
       - libavahi-client-dev
       - libjsoncpp-dev
       - libprotobuf-dev
@@ -177,7 +177,11 @@ parts:
       ' src/web/CMakeLists.txt
 
       # Add the compile option to override the posix socket
-      sed -i '/^target_compile_options/a ${WEB_CFLAGS}' src/web/CMakeLists.txt
+      sed -i '/^target_include_directories/i \
+      target_compile_options(otbr-web PRIVATE\
+      ${WEB_CFLAGS}\
+      )\
+      ' src/web/CMakeLists.txt
 
       # TODO: Avoid setting INFRA_IF_NAME here
       # The value is passed to cmake-build and then added to /etc/default/otbr-agent


### PR DESCRIPTION
Upstream's CMakeLists.txt for the web interface changes in commit [23149c3](https://github.com/openthread/ot-br-posix/commit/23149c321741f7800bd551713924b50380e828a0#diff-81d80f1c0e21284b793f318288673b4f3518f31c42e0b46451055996677d7b82L47-L51). This broke our `sed` command that rewrites the Posix Domain Socket used by the web interface. #61 solved the issue by adding a second `sed` command. This PR removes the redundant `sed` in favor of a single one.

Other small cleanup work is also done to the snapcraft.yaml.

Tested using:
* Manual review that issue in webui is solved
* `$ LOCAL_SERVICE_SNAP=~/openthread-border-router-snap/openthread-border-router_thread-reference-20250612+snap_amd64.snap INFRA_IF=enp0s13f0u3u4 go test -v -failfast -count 1`