### PR TITLE
Tests: reset systemd service failure counts

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -159,9 +159,8 @@ func resetServiceFailureCount(t *testing.T) {
 		"snap.openthread-border-router.otbr-web.service",
 	}
 	for _, service := range services {
-		command := "sudo systemctl reset-failed " + service
-		output, err := exec.Command("/bin/bash", "-c", command).CombinedOutput()
-		t.Logf("[exec] %s", command)
+		output, err := exec.Command("sudo", "systemctl", "reset-failed", service).CombinedOutput()
+		t.Logf("[exec] sudo systemctl reset-failed %s", service)
 		if err != nil {
 			// Ignore error, just log it
 			t.Log(string(output))

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -153,11 +153,18 @@ func waitForApplicationLogMessage(t *testing.T, application, expectedLog string,
 }
 
 func resetServiceFailureCount(t *testing.T) {
-	command := "sudo systemctl reset-failed snap.openthread-border-router.otbr-agent.service"
-	output, err := exec.Command("/bin/bash", "-c", command).CombinedOutput()
-	t.Logf("[exec] %s", command)
-	if err != nil {
-		// Ignore error, just log it
-		t.Log(string(output))
+	services := []string{
+		"snap.openthread-border-router.otbr-agent.service",
+		"snap.openthread-border-router.otbr-setup.service",
+		"snap.openthread-border-router.otbr-web.service",
+	}
+	for _, service := range services {
+		command := "sudo systemctl reset-failed " + service
+		output, err := exec.Command("/bin/bash", "-c", command).CombinedOutput()
+		t.Logf("[exec] %s", command)
+		if err != nil {
+			// Ignore error, just log it
+			t.Log(string(output))
+		}
 	}
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -18,6 +18,7 @@ func TestSetup(t *testing.T) {
 	utils.SnapStop(t, otbrSnap)
 
 	t.Cleanup(func() {
+		resetServiceFailureCount(t)
 		utils.SnapStop(t, otbrSnap)
 	})
 

--- a/tests/snap_services_test.go
+++ b/tests/snap_services_test.go
@@ -13,6 +13,7 @@ func TestSnapServicesStatus(t *testing.T) {
 	utils.SnapStop(t, otbrSnap)
 
 	t.Cleanup(func() {
+		resetServiceFailureCount(t)
 		utils.SnapStop(t, otbrSnap)
 	})
 

--- a/tests/socket_test.go
+++ b/tests/socket_test.go
@@ -13,6 +13,7 @@ func TestSocketFile(t *testing.T) {
 	utils.SnapStop(t, otbrSnap)
 
 	t.Cleanup(func() {
+		resetServiceFailureCount(t)
 		utils.SnapStop(t, otbrSnap)
 	})
 


### PR DESCRIPTION
## Summary
<!-- PR description, link to related documents and PRs -->

The tests fail intermittently. They intentionally cause the services to fail, due to invalid configurations. If this happens more than 10 times per 10 seconds, systemd disables the service.

This PR resets the service fail counter for all three services, avoiding this issue.

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->

## Testing steps
<!-- Steps to test the changes -->

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
