### PR TITLE
Append snap repo git hash to version

### DIFF
--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           lfs: true
-          ref: ${{ github.head_ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Build snap
         uses: snapcore/action-build@v1

--- a/.github/workflows/build-and-test-snap.yml
+++ b/.github/workflows/build-and-test-snap.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           lfs: true
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Build snap
         uses: snapcore/action-build@v1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: openthread-border-router
 # license: TBA
 summary: Snap packaging of OpenThread Border Router project for POSIX systems
 description: Refer to https://snapcraft.io/openthread-border-router
-adopt-info: otbr
+adopt-info: version
 
 base: core24
 
@@ -148,7 +148,8 @@ parts:
       - libjsoncpp-dev
       - libprotobuf-lite32t64
     override-build: |
-      craftctl set version="$(git describe --tags)+snap"
+      # Store OTBR tag for version part
+      git describe --tags > $CRAFT_PART_INSTALL/otbr-version
 
       # Setup scripts
       # Remove sudo from scripts
@@ -197,6 +198,24 @@ parts:
              $CRAFT_PART_INSTALL/usr/share/otbr-web/
 
       craftctl default
+    prime:
+      - -otbr-version # version file not needed in final snap
+
+  version:
+    after:
+      - otbr
+    plugin: nil
+    source: .
+    build-packages:
+      - git
+      - git-lfs
+    override-pull: |
+      # do nothing
+    override-build: |
+      set -eo pipefail
+      otbr_version=$(cat "$CRAFT_STAGE/otbr-version")
+      git_hash=$(git -C "$CRAFT_PROJECT_DIR" describe --always --dirty)
+      craftctl set version="${otbr_version}+${git_hash}"
 
   license:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -149,7 +149,7 @@ parts:
       - libprotobuf-lite32t64
     override-build: |
       # Store OTBR tag for version part
-      git describe --tags > $CRAFT_PART_INSTALL/otbr-version
+      git describe --tags --always > "$CRAFT_PART_INSTALL/otbr-version"
 
       # Setup scripts
       # Remove sudo from scripts

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -209,10 +209,7 @@ parts:
     build-packages:
       - git
       - git-lfs
-    override-pull: |
-      # do nothing
     override-build: |
-      set -eo pipefail
       otbr_version=$(cat "$CRAFT_STAGE/otbr-version")
       git_hash=$(git -C "$CRAFT_PROJECT_DIR" describe --always --dirty)
       craftctl set version="${otbr_version}+${git_hash}"


### PR DESCRIPTION
## Summary
<!-- PR description, link to related documents and PRs -->

Similar to our other snaps, this appends the snap repo's hash to the snap version string. This is for better traceability between snap versions in the store, back to which commit on this repo they were built from.

## Related issues
<!-- Add issues in bullets. Use Github keywords to link the PR to issues -->

## Testing steps
<!-- Steps to test the changes -->

<!-- Reminders:
 - Remove empty sections
 - Increment the version
 - Add/update tests
 - Update CI/CD pipelines
 - Update README(s)
 - Update external docs
-->
